### PR TITLE
Downgrade to ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
     php-tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         strategy:
             matrix:


### PR DESCRIPTION
Ubuntu 22.04 (`ubuntu-latest`) comes pre-packages with a cURL and/or openSSL-version that does not support pk12 (see https://github.com/Kong/insomnia/issues/5059#issuecomment-1212525150). 

Currently downgrading to 20.04 to letting the tests pass while looking into the issue.