### PR TITLE
Exclude non-essential files in production environments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+/tests export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpstan.neon export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore
+/UPGRADE.md export-ignore


### PR DESCRIPTION
This will exclude this file when downloading packages in production, thus saving space.