### PR TITLE
Load certificated paths using Laravel's filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ return [
 
 This may also be a good place to keep you payee-alias, callback-url and such, which you can then access with `config('swish.payee_alias)` etc.
 
-It's recommended to store certificates in the `storage/app/private` directory, which is protected by default. Provide relative paths, as they will be automatically resolved from your Laravel application's `storage/app/private` directory.
+For convenience and security, you can use relative paths to reference your certificates. Laravel will automatically resolve these paths from the `⁠storage/app/private` directory.
 
 ```env
 SWISH_CLIENT_CERTIFICATE_PATH=swish/client.pem # storage/app/private/swish/client.pem
+```
+
+If you prefer to keep your certificates in a specific location outside the default storage directory, you can provide an absolute path. However, be aware that when using an absolute path, the package will not utilize the filesystem to resolve the relative path.
+
+```env
+SWISH_CLIENT_CERTIFICATE_PATH=/absolute/path/swish/client.pem
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ return [
 
 This may also be a good place to keep you payee-alias, callback-url and such, which you can then access with `config('swish.payee_alias)` etc.
 
+It's recommended to store certificates in the `storage/app/private` directory, which is protected by default. Provide relative paths, as they will be automatically resolved from your Laravel application's `storage/app/private` directory.
+
 ## Usage
 
 A typical case for creating a Swish-payment.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ This may also be a good place to keep you payee-alias, callback-url and such, wh
 
 It's recommended to store certificates in the `storage/app/private` directory, which is protected by default. Provide relative paths, as they will be automatically resolved from your Laravel application's `storage/app/private` directory.
 
+```env
+SWISH_CLIENT_CERTIFICATE_PATH=swish/client.pem # storage/app/private/swish/client.pem
+```
+
 ## Usage
 
 A typical case for creating a Swish-payment.

--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Olssonm\Swish\Providers;
 
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use Olssonm\Swish\Certificate;
 use Olssonm\Swish\Client;
@@ -19,14 +18,18 @@ class SwishServiceProvider extends ServiceProvider
         $this->mergeConfigFrom($source, 'swish');
 
         $this->app->singleton('swish', function (Container $app): Client {
+            /** @var \Illuminate\Config\Repository $config */
             $config = $app->get('config');
 
+            /** @var \Illuminate\Filesystem\FilesystemAdapter $storage */
+            $storage = $app->get('filesystem');
+
             $certificate = new Certificate(
-                clientPath: Storage::path($config['swish.certificates.client']),
+                clientPath: $storage->path($config['swish.certificates.client']),
                 passphrase: $config['swish.certificates.password'],
-                rootPath: Storage::path($config['swish.certificates.root']),
-                signingPath: Storage::path($config['swish.certificates.signing']),
-                signingPassphrase: $config['swish.certificates.signing_password'],
+                rootPath: $storage->path($config['swish.certificates.root']),
+                signingPath: $storage->path($config['swish.certificates.signing']),
+                signingPassphrase: $config['swish.certificates.signing_password']
             );
 
             return new Client($certificate, $config['swish.endpoint']);

--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Olssonm\Swish\Providers;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Support\ServiceProvider;
 use Olssonm\Swish\Certificate;
 use Olssonm\Swish\Client;
@@ -13,7 +14,7 @@ class SwishServiceProvider extends ServiceProvider
     {
         $source = realpath($raw = __DIR__ . '/../../config/swish.php') ?: $raw;
 
-        $this->publishes([$source => config_path('swish.php')]);
+        $this->publishes([$source => config_path('swish.php')], 'config');
 
         $this->mergeConfigFrom($source, 'swish');
 
@@ -21,26 +22,34 @@ class SwishServiceProvider extends ServiceProvider
             /** @var \Illuminate\Config\Repository $config */
             $config = $app->get('config');
 
-            /** @var \Illuminate\Filesystem\FilesystemAdapter $storage */
+            /** @var \Illuminate\Filesystem\FilesystemManager $storage */
             $storage = $app->get('filesystem');
 
             $certificate = new Certificate(
-                clientPath: $storage->path($config['swish.certificates.client']),
-                passphrase: $config['swish.certificates.password'],
-                rootPath: $storage->path($config['swish.certificates.root']),
-                signingPath: $storage->path($config['swish.certificates.signing']),
-                signingPassphrase: $config['swish.certificates.signing_password']
+                clientPath: $this->resolvePath($storage, $config->get('swish.certificates.client')),
+                passphrase: $config->get('swish.certificates.password'),
+                rootPath: $this->resolvePath($storage, $config->get('swish.certificates.root')),
+                signingPath: $this->resolvePath($storage, $config->get('swish.certificates.signing')),
+                signingPassphrase: $config->get('swish.certificates.signing_password')
             );
 
-            return new Client($certificate, $config['swish.endpoint']);
+            return new Client($certificate, $config->get('swish.endpoint'));
         });
 
         $this->app->alias('swish', Client::class);
     }
 
-    /**
-     * @return array<string>
-     */
+    private function resolvePath(FilesystemManager $storage, string $path): string
+    {
+        return $this->isAbsolutePath($path) ? $path : $storage->path($path);
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return $path !== '' && ($path[0] === '/' || $path[0] === '\\' || (strlen($path) > 3 && ctype_alpha($path[0]) && $path[1] === ':' && ($path[2] === '\\' || $path[2] === '/')));
+    }
+
+    /** @return array<string> */
     public function provides(): array
     {
         return ['swish'];

--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Olssonm\Swish\Providers;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use Olssonm\Swish\Certificate;
 use Olssonm\Swish\Client;
@@ -19,11 +20,12 @@ class SwishServiceProvider extends ServiceProvider
 
         $this->app->singleton('swish', function (Container $app): Client {
             $config = $app->get('config');
+
             $certificate = new Certificate(
-                clientPath: $config['swish.certificates.client'],
+                clientPath: Storage::path($config['swish.certificates.client']),
                 passphrase: $config['swish.certificates.password'],
-                rootPath: $config['swish.certificates.root'],
-                signingPath: $config['swish.certificates.signing'],
+                rootPath: Storage::path($config['swish.certificates.root']),
+                signingPath: Storage::path($config['swish.certificates.signing']),
                 signingPassphrase: $config['swish.certificates.signing_password'],
             );
 


### PR DESCRIPTION
When deploying an application to Laravel Cloud, you need to upload the certificates to a bucket. Since we can't use the `Storage` facade in the configuration files, I had to create a custom service provider to load the certificates myself. I then wondered if there might be a better approach for all Laravel users of this package. Although this is a breaking change, Laravel itself seems to recommend placing these files in the `storage/app/private` directory, which is ignored by default.

This will use the [default filesystem](https://laravel.com/docs/12.x/filesystem#the-local-driver) configuration. If you set the Laravel Cloud bucket to default, it will work automatically.