### PR TITLE
Issue when resolving "null"-paths

### DIFF
--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -39,8 +39,12 @@ class SwishServiceProvider extends ServiceProvider
         $this->app->alias('swish', Client::class);
     }
 
-    private function resolvePath(FilesystemManager $storage, string $path): string
+    private function resolvePath(FilesystemManager $storage, ?string $path): string
     {
+        if (empty($path)) {
+            return '';
+        }
+
         return $this->isAbsolutePath($path) ? $path : $storage->path($path);
     }
 

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -62,3 +62,8 @@ function get_mock_client($code, $expectedHeaders, $expectedBody, &$history, $sig
         'base_uri' => Client::TEST_ENDPOINT,
     ]));
 }
+
+function get_facade_client()
+{
+    return app('swish');
+}

--- a/tests/ServiceProvider.php
+++ b/tests/ServiceProvider.php
@@ -3,6 +3,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Filesystem\FilesystemManager;
 use Olssonm\Swish\Certificate;
 use Olssonm\Swish\Client;
+use Olssonm\Swish\Facades\Swish;
 use Olssonm\Swish\Providers\SwishServiceProvider;
 
 it('resolves absolute paths correctly', function () {
@@ -132,4 +133,17 @@ it('registers the swish singleton correctly', function () {
 it('provides the correct services', function () {
     $provider = new SwishServiceProvider(mock(Container::class));
     expect($provider->provides())->toBe(['swish']);
+});
+
+it('resolves facade with missing keys', function () {
+    // Expect the Swish facade to fail if the config keys are null
+    config()->set('swish.certificates.client', null);
+    config()->set('swish.certificates.password', null);
+    config()->set('swish.certificates.root', null);
+    config()->set('swish.certificates.signing', null);
+    config()->set('swish.certificates.signing_password', null);
+
+    // In <= v3.2 this threw an exception
+    $client = get_facade_client();
+    expect($client)->toBeInstanceOf(Client::class);
 });


### PR DESCRIPTION
The `SWISH_SIGNING_CERTIFICATE_PATH` defaults to `null`, but `null`-values will cause the new path resolver to fail.

This PR allows `null` as path (and will return an empty string).