### PR TITLE
Fix return type of resolvePath method to allow boolean

### DIFF
--- a/config/swish.php
+++ b/config/swish.php
@@ -4,7 +4,7 @@ return [
     'certificates' => [
         'client' => env('SWISH_CLIENT_CERTIFICATE_PATH'),
         'password' => env('SWISH_CLIENT_CERTIFICATE_PASSWORD'),
-        'root' => env('SWISH_ROOT_CERTIFICATE_PATH'),
+        'root' => env('SWISH_ROOT_CERTIFICATE_PATH', true),
         'signing' => env('SWISH_SIGNING_CERTIFICATE_PATH'), // Optional, used for payouts
         'signing_password' => env('SWISH_SIGNING_CERTIFICATE_PASSWORD'), // Optional, used for payouts
     ],

--- a/config/swish.php
+++ b/config/swish.php
@@ -4,9 +4,9 @@ return [
     'certificates' => [
         'client' => env('SWISH_CLIENT_CERTIFICATE_PATH'),
         'password' => env('SWISH_CLIENT_CERTIFICATE_PASSWORD'),
-        'root' => env('SWISH_ROOT_CERTIFICATE_PATH', true),
-        'signing' => env('SWISH_SIGNING_CERTIFICATE_PATH', null), // Optional, used for payouts
-        'signing_password' => env('SWISH_SIGNING_CERTIFICATE_PASSWORD', null), // Optional, used for payouts
+        'root' => env('SWISH_ROOT_CERTIFICATE_PATH'),
+        'signing' => env('SWISH_SIGNING_CERTIFICATE_PATH'), // Optional, used for payouts
+        'signing_password' => env('SWISH_SIGNING_CERTIFICATE_PASSWORD'), // Optional, used for payouts
     ],
     'endpoint' => env('SWISH_URL', \Olssonm\Swish\Client::PRODUCTION_ENDPOINT),
 ];

--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -39,10 +39,10 @@ class SwishServiceProvider extends ServiceProvider
         $this->app->alias('swish', Client::class);
     }
 
-    private function resolvePath(FilesystemManager $storage, ?string $path): string
+    private function resolvePath(FilesystemManager $storage, ?string $path): bool|string
     {
         if (empty($path)) {
-            return '';
+            return false;
         }
 
         return $this->isAbsolutePath($path) ? $path : $storage->path($path);

--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -39,10 +39,14 @@ class SwishServiceProvider extends ServiceProvider
         $this->app->alias('swish', Client::class);
     }
 
-    private function resolvePath(FilesystemManager $storage, ?string $path): bool|string
+    private function resolvePath(FilesystemManager $storage, bool|string|null $path): bool|string
     {
-        if (empty($path)) {
-            return false;
+        if (is_bool($path)) {
+            return $path;
+        }
+
+        if ($path === '' || $path === null) {
+            return '';
         }
 
         return $this->isAbsolutePath($path) ? $path : $storage->path($path);


### PR DESCRIPTION
If the root certificate configuration is empty or null, it now returns `storage/app/private/1` instead of false.