### PR TITLE
Added callbackIdentifier property to Payment class

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -9,6 +9,7 @@ use Olssonm\Swish\Util\Uuid;
  * @property string $payeePaymentReference
  * @property string $paymentReference
  * @property string $callbackUrl
+ * @property string $callbackIdentifier
  * @property string $payerAlias
  * @property string $payeeAlias
  * @property string $amount


### PR DESCRIPTION
Thank you for this library!

Just added a property comment line to the Payment class for the optional payment request parameter `callbackIdentifier`, as per the [documentation](https://developer.swish.nu/api/payment-request/v2#payment-request-object).