### PR TITLE
Update conditional with `is_bool` function

### DIFF
--- a/src/Providers/SwishServiceProvider.php
+++ b/src/Providers/SwishServiceProvider.php
@@ -28,7 +28,7 @@ class SwishServiceProvider extends ServiceProvider
             $certificate = new Certificate(
                 clientPath: $this->resolvePath($storage, $config->get('swish.certificates.client')),
                 passphrase: $config->get('swish.certificates.password'),
-                rootPath: $config->get('swish.certificates.root') === true || $config->get('swish.certificates.root') === false
+                rootPath: is_bool($config->get('swish.certificates.root'))
                     ? $config->get('swish.certificates.root')
                     : $this->resolvePath($storage, $config->get('swish.certificates.root')),
                 signingPath: $this->resolvePath($storage, $config->get('swish.certificates.signing')),


### PR DESCRIPTION
This pull request includes a small change to the `SwishServiceProvider` class. The change simplifies the conditional logic for determining the `rootPath` by replacing a comparison with `true` or `false` with a call to [`is_bool`](https://www.php.net/manual/en/function.is-bool.php).